### PR TITLE
Fix case of LinkRelHTMLWebpackPlugin in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const { LinkRelHTMLWebpackPlugin } = require('link-rel-html-webpack-plugin');
 When using Node 4.x or 5.x you don't have deconstruction assignment, instead use: 
 
 ```js
-const LinkRelHtmlWebpackPlugin = require('link-rel-html-webpack-plugin').LinkRelHTMLWebpackPlugin;
+const LinkRelHTMLWebpackPlugin = require('link-rel-html-webpack-plugin').LinkRelHTMLWebpackPlugin;
 ```
 
 and add it to your webpack config as follows:
@@ -43,7 +43,7 @@ and add it to your webpack config as follows:
 plugins: [
     // ...
     new HtmlWebpackPlugin(),
-    new LinkRelHtmlWebpackPlugin({
+    new LinkRelHTMLWebpackPlugin({
         files: [
             { file: /theme-default/, title: 'Default Theme' },
             { file: /theme-dark/, rel: 'alternate stylesheet', title:  => 'Dark Theme' }

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Basic Usage
 Load the plugin
 
 ```js
-const { LinkRelHtmlWebpackPlugin } = require('link-rel-html-webpack-plugin');
+const { LinkRelHTMLWebpackPlugin } = require('link-rel-html-webpack-plugin');
 ```
 
 When using Node 4.x or 5.x you don't have deconstruction assignment, instead use: 
 
 ```js
-const LinkRelHtmlWebpackPlugin = require('link-rel-html-webpack-plugin').LinkRelHtmlWebpackPlugin;
+const LinkRelHtmlWebpackPlugin = require('link-rel-html-webpack-plugin').LinkRelHTMLWebpackPlugin;
 ```
 
 and add it to your webpack config as follows:


### PR DESCRIPTION
Readme uses the wrong case for HTML. This fixes that so copy/pasting the examples now works